### PR TITLE
Fixed KP/ST error; added * and # as aliases for the dialstring

### DIFF
--- a/MainApp/build.gradle
+++ b/MainApp/build.gradle
@@ -19,7 +19,7 @@ android {
     buildToolsVersion "22.0.1"
 
     defaultConfig {
-        minSdkVersion 17
+        minSdkVersion 8
         targetSdkVersion 22
         versionCode 11
         versionName "11"

--- a/MainApp/build.gradle
+++ b/MainApp/build.gradle
@@ -19,7 +19,7 @@ android {
     buildToolsVersion "22.0.1"
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 17
         targetSdkVersion 22
         versionCode 11
         versionName "11"

--- a/MainApp/src/main/java/com/bytestemplar/tonedef/tones/ToneBankBlueBox.java
+++ b/MainApp/src/main/java/com/bytestemplar/tonedef/tones/ToneBankBlueBox.java
@@ -72,8 +72,10 @@ public class ToneBankBlueBox extends ToneBank
         addEntry( '9', new SequenceDefinition( 250, 1100, 1500 ) );
 
         addEntry( 'K', new SequenceDefinition( 250, 1100, 1700 ) );
+        addEntry( '*', new SequenceDefinition( 250, 1100, 1700 ) );
         addEntry( '0', new SequenceDefinition( 250, 1300, 1500 ) );
         addEntry( 'S', new SequenceDefinition( 250, 1500, 1700 ) );
+        addEntry( '#', new SequenceDefinition( 250, 1500, 1700 ) );
 
         addEntry( 'X', new SequenceDefinition( 250, 2600 ) );
     }

--- a/MainApp/src/main/res/layout/touchpad_bluebox.xml
+++ b/MainApp/src/main/res/layout/touchpad_bluebox.xml
@@ -24,9 +24,9 @@
         <ImageButton android:id="@+id/blu9" style="@style/TouchPadButtons" android:src="@drawable/dtmf9" android:contentDescription="9"/>
     </LinearLayout>
     <LinearLayout style="@style/TouchPadRow" >
-        <ImageButton android:id="@+id/blus" style="@style/TouchPadButtons" android:src="@drawable/blustar" android:contentDescription="S"/>
+        <ImageButton android:id="@+id/bluk" style="@style/TouchPadButtons" android:src="@drawable/blustar" android:contentDescription="K"/>
         <ImageButton android:id="@+id/blu0" style="@style/TouchPadButtons" android:src="@drawable/dtmf0" android:contentDescription="0"/>
-        <ImageButton android:id="@+id/bluk" style="@style/TouchPadButtons" android:src="@drawable/blupound" android:contentDescription="K"/>
+        <ImageButton android:id="@+id/blus" style="@style/TouchPadButtons" android:src="@drawable/blupound" android:contentDescription="S"/>
     </LinearLayout>
 
 </LinearLayout>

--- a/MainApp/src/main/res/layout/touchpad_container.xml
+++ b/MainApp/src/main/res/layout/touchpad_container.xml
@@ -38,8 +38,6 @@
                 android:textColor="#FFFFFF"
                 android:onClick="clickDial"
                 android:text="@string/dial_button"
-                android:paddingStart="40dp"
-                android:paddingEnd="40dp"
                 android:textSize="20sp"
                 android:textStyle="bold"/>
     </LinearLayout>

--- a/MainApp/src/main/res/menu/touchpad_menu.xml
+++ b/MainApp/src/main/res/menu/touchpad_menu.xml
@@ -6,12 +6,12 @@
         android:id="@+id/menu_contactpick"
         android:icon="@android:drawable/ic_menu_call"
         android:title="@string/dial_contact"
-        android:showAsAction="ifRoom|withText" />
+        app:showAsAction="ifRoom|withText" />
 
     <item
         android:id="@+id/menu_settings"
         android:icon="@android:drawable/ic_menu_preferences"
         android:title="@string/settings_full"
-        android:showAsAction="ifRoom|withText" />
+        app:showAsAction="ifRoom|withText" />
 
 </menu>


### PR DESCRIPTION
KP and ST were transposed on the keyboard. Fixed this, and added \* and # as aliases on the dialstring so it is possible to preset a full MF sequence. You can hear this – KP has one tone that's lower than ST.

I also changed whatever lint told me to change to make it compile. I can yank those out if you don't want them in the merge request.

Incidentally, this is a super awesome project. I have successfully used the MF dialer on real equipment – or at least, I did once I figured out that the KP and ST tones were transposed :D
